### PR TITLE
feat: add Issue templates for feature requests and child tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/child-task.yml
+++ b/.github/ISSUE_TEMPLATE/child-task.yml
@@ -1,0 +1,38 @@
+name: 子タスク
+description: タスク分割エージェントが親 Issue から分割した実装タスク
+labels:
+  - ready-for-impl
+body:
+  - type: markdown
+    attributes:
+      value: |
+        このテンプレートはタスク分割エージェントが自動的に使用します。手動起票には通常 `機能要求` テンプレートを使ってください。
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: タスクの説明
+    validations:
+      required: true
+  - type: input
+    id: parent
+    attributes:
+      label: 親 Issue
+      description: 親となる Issue 番号（例：#42）
+      placeholder: "#"
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: 実装方針
+      description: 設計書から抜粋した実装方針
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 完了条件
+      description: 具体的な完了基準
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,33 @@
+name: 機能要求
+description: 新しい機能や改善の要求を起票する
+labels:
+  - 要件定義作成
+body:
+  - type: markdown
+    attributes:
+      value: |
+        このテンプレートで起票すると、自動的に要件定義エージェントが起動します。
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 実現したいことを簡潔に書いてください
+    validations:
+      required: true
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景・動機
+      description: なぜこの機能が必要か、現状の課題を書いてください
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: 要件（わかる範囲で）
+      description: 具体的な要件や制約があれば書いてください。不明な点は要件定義エージェントが質問します
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 完了条件（わかる範囲で）
+      description: どうなったら完了とみなせるかを書いてください


### PR DESCRIPTION
## 変更概要

Closes haruvv/dev-agents#2

## 実施内容

- `.github/ISSUE_TEMPLATE/feature-request.yml`：機能要求テンプレートを追加。`要件定義作成` ラベルをデフォルト付与し、要件定義エージェントを自動起動
- `.github/ISSUE_TEMPLATE/child-task.yml`：子タスクテンプレートを追加。`ready-for-impl` ラベルをデフォルト付与し、実装エージェントを自動起動。設計書 §2.3 の子 Issue フォーマット（概要・親 Issue・実装方針・完了条件）に準拠

## テスト実施内容

- GitHub の Issue 作成画面でテンプレートが選択肢として表示されることを確認（push 後に目視確認予定）
- YAML 構文は Codex レビューで問題なしを確認

## 懸念点 / 未対応事項

なし

## レビュー観点

- `feature-request.yml` のデフォルトラベルが `要件定義作成` になっているか
- `child-task.yml` のデフォルトラベルが `ready-for-impl` になっているか
- 子タスクフォーマット（概要・親 Issue・実装方針・完了条件）が設計書 §2.3 と一致しているか