### PR TITLE
fix: ラベル残存リスクを3点修正

### DIFF
--- a/.github/workflows/claude-impl.yml
+++ b/.github/workflows/claude-impl.yml
@@ -147,9 +147,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "ready-for-review"
-          if [ -n "${{ env.ISSUE_NUMBER }}" ]; then
-            gh issue edit "${{ env.ISSUE_NUMBER }}" --remove-label "in-impl"
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          gh pr edit "$PR_NUMBER" --add-label "ready-for-review"
+          ISSUE_NUMBER="${{ env.ISSUE_NUMBER }}"
+          # ブランチ名から抽出できなかった場合は PR 本文の "Closes #<n>" から取得
+          if [ -z "$ISSUE_NUMBER" ]; then
+            ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --json body --jq '.body' | grep -oP '(?<=#)\d+' | head -1)
+          fi
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue edit "$ISSUE_NUMBER" --remove-label "in-impl"
           fi
 
       # 失敗時: in-impl 除去・blocked 付与・コメント

--- a/.github/workflows/claude-requirements.yml
+++ b/.github/workflows/claude-requirements.yml
@@ -53,6 +53,7 @@ jobs:
           ISSUE_NUMBER=${{ github.event.issue.number }}
           gh issue edit "$ISSUE_NUMBER" \
             --remove-label "要件定義作成" \
+            --remove-label "in-requirements" \
             --add-label "blocked" \
             --add-label "needs-human"
           gh issue comment "$ISSUE_NUMBER" --body "## ⚠️ 質問ループ上限超過


### PR DESCRIPTION
## Summary

- `claude-requirements.yml`: ループ上限超過時に `in-requirements` を除去し忘れていたのを修正（`要件定義作成` と同時に除去）
- `claude-impl.yml`: PR トリガーでブランチ名から `ISSUE_NUMBER` が取得できなかった場合、PR 本文の `Closes #<n>` からフォールバック取得するよう修正。これにより `in-impl` の残存を防ぐ

## 関連

設計書 (`agent-dev-studio/docs/design.md`) のブランチ名記述も `impl/<issue-number>-<title>` → `impl/issue-<issue-number>-<slug>` に合わせて修正済み。

## Test plan

- [ ] ループ上限超過時に `in-requirements` が残存しないこと
- [ ] PR トリガーで `ISSUE_NUMBER` 未取得時も `in-impl` が確実に除去されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)